### PR TITLE
Added autoloader to composer and corrected bug in php 5.3

### DIFF
--- a/SwaggerGen/Swagger/AbstractObject.php
+++ b/SwaggerGen/Swagger/AbstractObject.php
@@ -125,7 +125,7 @@ abstract class AbstractObject
 	 */
 	public static function array_toArray(&$array)
 	{
-		return array_map(function(self $item) {
+		return array_map(function($item) {
 			return $item->toArray();
 		}, $array);
 	}

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,10 @@
 	},
 	"require": {
 		"php": ">=5.3.0"
-	}
+	},
+	"autoload": {
+        "psr-4": {
+            "SwaggerGen": "SwaggerGen/"
+        }
+    },
 }
-

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
 		"php": ">=5.3.0"
 	},
 	"autoload": {
-        "psr-4": {
-            "SwaggerGen": "SwaggerGen/"
-        }
-    },
+		"psr-4": {
+			"SwaggerGen": "SwaggerGen/"
+		}
+	}
 }


### PR DESCRIPTION
Adding the autoload will enable people to automatically have composer setup their autoloader when they run composer install.

Also, in my environment, having self $item in the callback caused a fatal exception. Removing it worked for us.

Thanks for the awesome library. I like the syntax of the comments so much better than swagger-php