### PR TITLE
Added a new "refobject" parameter for individual definition references

### DIFF
--- a/SwaggerGen/Swagger/Type/Property.php
+++ b/SwaggerGen/Swagger/Type/Property.php
@@ -89,7 +89,7 @@ class Property extends \SwaggerGen\Swagger\AbstractObject
 	public function toArray()
 	{
 		return self::arrayFilterNull(array_merge($this->Type->toArray(), array(
-					'description' => $this->description,
+					'description' => empty($this->description) ? null : $this->description,
 								), parent::toArray()));
 	}
 

--- a/SwaggerGen/Swagger/Type/Property.php
+++ b/SwaggerGen/Swagger/Type/Property.php
@@ -38,6 +38,7 @@ class Property extends \SwaggerGen\Swagger\AbstractObject
 		'datetime' => 'Date',
 		'date-time' => 'Date',
 		'object' => 'Object',
+        'refobject' => 'ReferenceObject',
 			//'file'	=> 'File';
 			//'set'		=> 'EnumArray';
 	);

--- a/SwaggerGen/Swagger/Type/ReferenceObjectType.php
+++ b/SwaggerGen/Swagger/Type/ReferenceObjectType.php
@@ -44,7 +44,6 @@ class ReferenceObjectType extends AbstractType
 	public function toArray()
 	{
 		return self::arrayFilterNull(array(
-					'type' => 'object',
 					'$ref' => '#/definitions/' . $this->reference,
 		));
 	}

--- a/SwaggerGen/Swagger/Type/ReferenceObjectType.php
+++ b/SwaggerGen/Swagger/Type/ReferenceObjectType.php
@@ -15,8 +15,29 @@ class ReferenceObjectType extends AbstractType
 
 	private $reference = null;
 
-	protected function parseDefinition($reference)
+	protected function parseDefinition($definition)
 	{
+        $definition = self::trim($definition);
+
+        $match = array();
+        if (preg_match(self::REGEX_START . self::REGEX_FORMAT . self::REGEX_CONTENT . self::REGEX_RANGE . self::REGEX_DEFAULT . self::REGEX_END, $definition, $match) !== 1) {
+            throw new \SwaggerGen\Exception("Unparseable string definition: '{$definition}'");
+        }
+
+        $type = strtolower($match[1]);
+
+        $reference = null;
+        if ($type === 'refobject') {
+            if (isset($match[2]))
+                $reference = $match[2];
+        } else {
+            $reference = $match[1];
+        }
+
+        if (empty($reference)) {
+            throw new \SwaggerGen\Exception("Referenced object name missing: '{$definition}'");
+        }
+
 		$this->reference = $reference;
 	}
 

--- a/tests/Swagger/BodyParameterTest.php
+++ b/tests/Swagger/BodyParameterTest.php
@@ -63,7 +63,6 @@ class BodyParameterTest extends PHPUnit_Framework_TestCase
 			'name' => 'foo',
 			'in' => 'body',
 			'schema' => array(
-				'type' => 'object',
 				'$ref' => '#/definitions/User',
 			),
 				), $object->toArray());

--- a/tests/Swagger/ResponseTest.php
+++ b/tests/Swagger/ResponseTest.php
@@ -73,7 +73,6 @@ class ResponseTest extends PHPUnit_Framework_TestCase
 		$this->assertSame(array(
 			'description' => 'OK',
 			'schema' => array(
-				'type' => 'object',
 				'$ref' => '#/definitions/User',
 			),
 				), $object->toArray());

--- a/tests/Swagger/SchemaTest.php
+++ b/tests/Swagger/SchemaTest.php
@@ -54,7 +54,6 @@ class SchemaTest extends PHPUnit_Framework_TestCase
 		$this->assertInstanceOf('\SwaggerGen\Swagger\Schema', $object);
 
 		$this->assertSame(array(
-			'type' => 'object',
 			'$ref' => '#/definitions/User',
 				), $object->toArray());
 	}

--- a/tests/Swagger/Type/ArrayTypeTest.php
+++ b/tests/Swagger/Type/ArrayTypeTest.php
@@ -167,7 +167,6 @@ class ArrayTypeTest extends PHPUnit_Framework_TestCase
 		$this->assertSame(array(
 			'type' => 'array',
 			'items' => array(
-				'type' => 'object',
 				'$ref' => '#/definitions/Item',
 			),
 				), $object->toArray());
@@ -326,7 +325,6 @@ class ArrayTypeTest extends PHPUnit_Framework_TestCase
 		$this->assertSame(array(
 			'type' => 'array',
 			'items' => array(
-				'type' => 'object',
 				'$ref' => '#/definitions/Item',
 			),
 				), $object->toArray());

--- a/tests/Swagger/Type/ReferenceObjectTypeTest.php
+++ b/tests/Swagger/Type/ReferenceObjectTypeTest.php
@@ -25,7 +25,6 @@ class ReferenceObjectTypeTest extends PHPUnit_Framework_TestCase
 		$this->assertInstanceOf('\SwaggerGen\Swagger\Type\ReferenceObjectType', $object);
 
 		$this->assertSame(array(
-			'type' => 'object',
 			'$ref' => '#/definitions/blah',
 				), $object->toArray());
 	}


### PR DESCRIPTION
Hello,

When using @rest\property, I noticed that you cannot specify a reference object type. Rather than simply falling back to a reference however, I thought it best to maintain that behaviour for nice user errors. To that end, I've added some parsing logic to the reference object, as well as a new 'refobject' property.