### PR TITLE
Read only property

### DIFF
--- a/README.md
+++ b/README.md
@@ -800,13 +800,15 @@ Object with properties. Typically used as key-value map
 	Empty `max` value means infinite properties (no maximum).
 *	definition: a comma-separated list of property definitions in the form of
 	`key:definition`, where `key` can be any sequence of characters except `:` or
-	`?`. The `?` means that key is optional.
+	`?` or `*`. The `?` means that key is optional. The `*` means the key is read only. 
+	Read only implies optional as well.
 
 ### Commands
 *	**`min` *value*** Set the minimum number of items required.
 *	**`max` *value*** Set the maximum number of items allowed.
 *	**`property` *definition name*** Add a required property.
 *	**`property?` *definition name*** Add an optional property.
+*   **`property*` *definition name*** Add a read only property.
 
 ### Examples
 *	**`object(age:int[18,25>)`** An object containing a single key `age` with

--- a/README.md
+++ b/README.md
@@ -800,7 +800,7 @@ Object with properties. Typically used as key-value map
 	Empty `max` value means infinite properties (no maximum).
 *	definition: a comma-separated list of property definitions in the form of
 	`key:definition`, where `key` can be any sequence of characters except `:` or
-	`?` or `*`. The `?` means that key is optional. The `*` means the key is read only. 
+	`?` or `!`. The `?` means that key is optional. The `!` means the key is read only. 
 	Read only implies optional as well.
 
 ### Commands
@@ -808,7 +808,7 @@ Object with properties. Typically used as key-value map
 *	**`max` *value*** Set the maximum number of items allowed.
 *	**`property` *definition name*** Add a required property.
 *	**`property?` *definition name*** Add an optional property.
-*   **`property*` *definition name*** Add a read only property.
+*   **`property!` *definition name*** Add a read only property.
 
 ### Examples
 *	**`object(age:int[18,25>)`** An object containing a single key `age` with

--- a/SwaggerGen/Swagger/Type/ObjectType.php
+++ b/SwaggerGen/Swagger/Type/ObjectType.php
@@ -13,8 +13,8 @@ namespace SwaggerGen\Swagger\Type;
 class ObjectType extends AbstractType
 {
 	const REGEX_PROP_START = '/^';
-	const REGEX_PROP_NAME = '([^?*:]+)';
-	const REGEX_PROP_REQUIRED = '([\?\*])?';
+	const REGEX_PROP_NAME = '([^?!:]+)';
+	const REGEX_PROP_REQUIRED = '([\?!])?';
 	const REGEX_PROP_ASSIGN = ':';
 	const REGEX_PROP_DEFINITION = '(.+)';
 	const REGEX_PROP_END = '$/';
@@ -59,7 +59,7 @@ class ObjectType extends AbstractType
 						throw new \SwaggerGen\Exception("Unparseable property definition: '{$property}'");
 					}
                     $this->properties[$prop_match[1]] = new Property($this, $prop_match[3]);
-                    if ($prop_match[2] !== '*' && $prop_match[2] !== '?') {
+                    if ($prop_match[2] !== '!' && $prop_match[2] !== '?') {
 						$this->required[$prop_match[1]] = true;
 					}
 				}
@@ -98,7 +98,7 @@ class ObjectType extends AbstractType
 			// type name description...
 			case 'property':
 			case 'property?':
-            case 'property*':
+            case 'property!':
 				$definition = self::wordShift($data);
 				if (empty($definition)) {
 					throw new \SwaggerGen\Exception("Missing property definition");
@@ -114,7 +114,7 @@ class ObjectType extends AbstractType
                 unset($this->required[$name]);
 				$readOnly = null;
                 $propertySuffix = substr($command, -1);
-                if ($propertySuffix === '*') {
+                if ($propertySuffix === '!') {
                     $readOnly = true;
                 }
 				else if ($propertySuffix !== '?') {

--- a/SwaggerGen/Swagger/Type/Property.php
+++ b/SwaggerGen/Swagger/Type/Property.php
@@ -48,6 +48,12 @@ class Property extends \SwaggerGen\Swagger\AbstractObject
 	 */
 	private $description;
 
+    /**
+     * Whether property is read only
+     * @var bool
+     */
+	private $readOnly;
+
 	/**
 	 * Type definition of this property
 	 * @var \SwaggerGen\Swagger\Type\AbstractType
@@ -59,9 +65,10 @@ class Property extends \SwaggerGen\Swagger\AbstractObject
 	 * @param \SwaggerGen\Swagger\AbstractObject $parent
 	 * @param string $definition Either a built-in type or a definition name
 	 * @param string $description description of the property
+     * @param bool $readOnly Whether the property is read only
 	 * @throws \SwaggerGen\Exception
 	 */
-	public function __construct(\SwaggerGen\Swagger\AbstractObject $parent, $definition, $description = null)
+	public function __construct(\SwaggerGen\Swagger\AbstractObject $parent, $definition, $description = null, $readOnly = null)
 	{
 		parent::__construct($parent);
 
@@ -80,6 +87,7 @@ class Property extends \SwaggerGen\Swagger\AbstractObject
 		}
 
 		$this->description = $description;
+		$this->readOnly = $readOnly;
 	}
 
 	/**
@@ -101,6 +109,7 @@ class Property extends \SwaggerGen\Swagger\AbstractObject
 	{
 		return self::arrayFilterNull(array_merge($this->Type->toArray(), array(
 					'description' => empty($this->description) ? null : $this->description,
+                    'readOnly' => $this->readOnly
 								), parent::toArray()));
 	}
 

--- a/tests/Swagger/Type/ObjectTypeTest.php
+++ b/tests/Swagger/Type/ObjectTypeTest.php
@@ -344,7 +344,7 @@ class ObjectTypeTest extends PHPUnit_Framework_TestCase
 			api Test
 			endpoint /test
 			method GET something
-			response 200 object(a*:array(A),b:array(B))
+			response 200 object(a!:array(A),b:array(B))
 		'));
 
         $this->assertSame('{"swagger":2,"info":{"title":"undefined","version":0}'

--- a/tests/Swagger/Type/ObjectTypeTest.php
+++ b/tests/Swagger/Type/ObjectTypeTest.php
@@ -152,42 +152,6 @@ class ObjectTypeTest extends PHPUnit_Framework_TestCase
 				), $object->toArray());
 	}
 
-    /**
-     * @covers \SwaggerGen\Swagger\Type\ObjectType::__construct
-     */
-    public function testConstructTypeReadOnlyProperty()
-    {
-        $object = new SwaggerGen\Swagger\Type\ObjectType($this->parent, 'object(foo:string,bar?:int[3,10>=5,baz*:string)');
-
-        $this->assertInstanceOf('\SwaggerGen\Swagger\Type\ObjectType', $object);
-
-        $this->assertSame(array(
-            'type' => 'object',
-            'required' => array(
-                'foo',
-            ),
-            'readOnly' => array(
-                'baz',
-            ),
-            'properties' => array(
-                'foo' => array(
-                    'type' => 'string',
-                ),
-                'bar' => array(
-                    'type' => 'integer',
-                    'format' => 'int32',
-                    'default' => 5,
-                    'minimum' => 3,
-                    'maximum' => 10,
-                    'exclusiveMaximum' => true,
-                ),
-                'baz' => array(
-                    'type' => 'string',
-                )
-            ),
-        ), $object->toArray());
-    }
-
 	/**
 	 * @covers \SwaggerGen\Swagger\Type\ObjectType->handleCommand
 	 */
@@ -355,31 +319,6 @@ class ObjectTypeTest extends PHPUnit_Framework_TestCase
 				), $object->toArray());
 	}
 
-    /**
-     * @covers \SwaggerGen\Swagger\Type\ObjectType->handleCommand
-     */
-    public function testCommandPropertyReadOnly()
-    {
-        $object = new SwaggerGen\Swagger\Type\ObjectType($this->parent, 'object');
-
-        $this->assertInstanceOf('\SwaggerGen\Swagger\Type\ObjectType', $object);
-
-        $object->handleCommand('property*', 'string foo Some words here');
-
-        $this->assertSame(array(
-            'type' => 'object',
-            'readOnly' => array(
-                'foo',
-            ),
-            'properties' => array(
-                'foo' => array(
-                    'type' => 'string',
-                    'description' => 'Some words here',
-                ),
-            ),
-        ), $object->toArray());
-    }
-
 	public function testObjectProperties()
 	{
 		$object = new \SwaggerGen\SwaggerGen();
@@ -397,6 +336,24 @@ class ObjectTypeTest extends PHPUnit_Framework_TestCase
 				. ',"b":{"type":"array","items":{"$ref":"#\/definitions\/B"}}}}}}}}}'
 				. ',"tags":[{"name":"Test"}]}', json_encode($array, JSON_NUMERIC_CHECK));
 	}
+
+    public function testObjectPropertiesReadOnly()
+    {
+        $object = new \SwaggerGen\SwaggerGen();
+        $array = $object->getSwagger(array('
+			api Test
+			endpoint /test
+			method GET something
+			response 200 object(a*:array(A),b:array(B))
+		'));
+
+        $this->assertSame('{"swagger":2,"info":{"title":"undefined","version":0}'
+            . ',"paths":{"\/test":{"get":{"tags":["Test"],"summary":"something"'
+            . ',"responses":{"200":{"description":"OK","schema":{"type":"object","required":["b"]'
+            . ',"properties":{"a":{"type":"array","items":{"$ref":"#\/definitions\/A"}}'
+            . ',"b":{"type":"array","items":{"$ref":"#\/definitions\/B"}}}}}}}}}'
+            . ',"tags":[{"name":"Test"}]}', json_encode($array, JSON_NUMERIC_CHECK));
+    }
 
 	public function testDeepObjectProperties()
 	{

--- a/tests/Swagger/Type/ObjectTypeTest.php
+++ b/tests/Swagger/Type/ObjectTypeTest.php
@@ -152,6 +152,42 @@ class ObjectTypeTest extends PHPUnit_Framework_TestCase
 				), $object->toArray());
 	}
 
+    /**
+     * @covers \SwaggerGen\Swagger\Type\ObjectType::__construct
+     */
+    public function testConstructTypeReadOnlyProperty()
+    {
+        $object = new SwaggerGen\Swagger\Type\ObjectType($this->parent, 'object(foo:string,bar?:int[3,10>=5,baz*:string)');
+
+        $this->assertInstanceOf('\SwaggerGen\Swagger\Type\ObjectType', $object);
+
+        $this->assertSame(array(
+            'type' => 'object',
+            'required' => array(
+                'foo',
+            ),
+            'readOnly' => array(
+                'baz',
+            ),
+            'properties' => array(
+                'foo' => array(
+                    'type' => 'string',
+                ),
+                'bar' => array(
+                    'type' => 'integer',
+                    'format' => 'int32',
+                    'default' => 5,
+                    'minimum' => 3,
+                    'maximum' => 10,
+                    'exclusiveMaximum' => true,
+                ),
+                'baz' => array(
+                    'type' => 'string',
+                )
+            ),
+        ), $object->toArray());
+    }
+
 	/**
 	 * @covers \SwaggerGen\Swagger\Type\ObjectType->handleCommand
 	 */
@@ -318,6 +354,31 @@ class ObjectTypeTest extends PHPUnit_Framework_TestCase
 			),
 				), $object->toArray());
 	}
+
+    /**
+     * @covers \SwaggerGen\Swagger\Type\ObjectType->handleCommand
+     */
+    public function testCommandPropertyReadOnly()
+    {
+        $object = new SwaggerGen\Swagger\Type\ObjectType($this->parent, 'object');
+
+        $this->assertInstanceOf('\SwaggerGen\Swagger\Type\ObjectType', $object);
+
+        $object->handleCommand('property*', 'string foo Some words here');
+
+        $this->assertSame(array(
+            'type' => 'object',
+            'readOnly' => array(
+                'foo',
+            ),
+            'properties' => array(
+                'foo' => array(
+                    'type' => 'string',
+                    'description' => 'Some words here',
+                ),
+            ),
+        ), $object->toArray());
+    }
 
 	public function testObjectProperties()
 	{

--- a/tests/Swagger/Type/PropertyTest.php
+++ b/tests/Swagger/Type/PropertyTest.php
@@ -81,6 +81,21 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
 				), $object->toArray());
 	}
 
+    /**
+     * @covers \SwaggerGen\Swagger\Type\PropertyType::__construct
+     */
+    public function testConstructReadOnly()
+    {
+        $object = new SwaggerGen\Swagger\Type\Property($this->parent, 'string', 'Some words here', true);
+        $this->assertInstanceOf('\SwaggerGen\Swagger\Type\Property', $object);
+
+        $this->assertSame(array(
+            'type' => 'string',
+            'description' => 'Some words here',
+            'readOnly' => true
+        ), $object->toArray());
+    }
+
 	/**
 	 * @covers \SwaggerGen\Swagger\Type\PropertyType::__construct
 	 */


### PR DESCRIPTION
The proposed functionality will allow object properties to be read only. Swagger-ui recognizes readOnly properties and displays properties as "read only". Swagger-ui v3 will eventually remove read only properties from example value for POST/PUT requests and only include in GET requests. This is helpful for properties like lastModified as it is part of the object, but should be written by the backend rather than passed via API. When reading the objects though, it is expected that lastModified be included in the data. This feature will allow properties like lastModified to be included in models, but behave as previously mentioned.