### PR TITLE
Allow definitions to be read only

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,7 +543,11 @@ The URL and email address will be automatically detected, the name will consist
 of all text remaining (properly separated with whitespace).
 
 ### `definintion` *`name`* &rArr; Schema
-Start definition of a Schema using the reference name specified.
+Start definition of a Schema using the reference name specified. 
+
+Definitions can be specified as read only using exclamation point at the end of
+the definition command. E.g. `definition! user` will create a user model that
+will appear in GET responses and be omitted from POST, PUT, and PATCH requests.
 
 alias: `model` (for historical reasons)
 

--- a/SwaggerGen/Swagger/Schema.php
+++ b/SwaggerGen/Swagger/Schema.php
@@ -51,6 +51,11 @@ class Schema extends AbstractDocumentableObject implements IDefinition
 	 */
 	private $title = null;
 
+    /**
+     * @var bool
+     */
+    private $readOnly = null;
+
 	/**
 	 * @var \SwaggerGen\Swagger\Type\AbstractType
 	 */
@@ -113,6 +118,7 @@ class Schema extends AbstractDocumentableObject implements IDefinition
 		return self::arrayFilterNull(array_merge($this->type->toArray(), array(
 					'title' => empty($this->title) ? null : $this->title,
 					'description' => empty($this->description) ? null : $this->description,
+                    'readOnly' => $this->readOnly
 								), parent::toArray()));
 	}
 
@@ -120,5 +126,10 @@ class Schema extends AbstractDocumentableObject implements IDefinition
 	{
 		return __CLASS__;
 	}
+
+    public function setReadOnly()
+    {
+        $this->readOnly = true;
+    }
 
 }

--- a/SwaggerGen/Swagger/Swagger.php
+++ b/SwaggerGen/Swagger/Swagger.php
@@ -142,8 +142,13 @@ class Swagger extends AbstractDocumentableObject
 				return $this;
 
 			case 'model':
+            case 'model!':
 			case 'definition':
+            case 'definition!':
 				$definition = new Schema($this);
+				if(substr($command, -1) === '!') {
+				    $definition->setReadOnly();
+                }
 				$name = self::wordShift($data);
 				if (empty($name)) {
 					throw new \SwaggerGen\Exception('Missing definition name');


### PR DESCRIPTION
Need the ability to make a model read only. Swagger does not allow object properties that are objects to be read only. In [swagger.io editor](http://editor.swagger.io/), attempting make an object property that is a reference read only will give warning "Values alongside a $ref will be ignored" and expected functionality will not work. To get around this, Swagger allows a model to be readonly. Now objects properties that reference the read only object will only be available in read responses and unavailable in write requests.