### PR TITLE
Assert on pretty-printed json with built-in json-equals assertion

### DIFF
--- a/tests/output/OutputTest.php
+++ b/tests/output/OutputTest.php
@@ -24,7 +24,10 @@ class OutputTest extends SwaggerGen_TestCase
 	 */
 	private function normalizeJson($json)
 	{
-		return json_encode(json_decode($json), JSON_PRETTY_PRINT);
+		return json_encode(
+			json_decode($json), 
+			PHP_VERSION_ID >= 50400 ? constant('JSON_PRETTY_PRINT') : 0
+		);
 	}
 	
 	public function provideAllCases() {

--- a/tests/output/OutputTest.php
+++ b/tests/output/OutputTest.php
@@ -11,7 +11,20 @@ class OutputTest extends SwaggerGen_TestCase
 	{
 		$SwaggerGen = new \SwaggerGen\SwaggerGen('example.com', '/base');
 		$actual = $SwaggerGen->getSwagger($files, array(), \SwaggerGen\SwaggerGen::FORMAT_JSON);
-		$this->assertSame($expected, $actual, $name);
+		$this->assertJsonStringEqualsJsonString($expected, $this->normalizeJson($actual), $name);
+	}
+
+	/**
+	 * Normalizes and pretty-prints json (whitespace mostly)
+	 *
+	 * This is useful to get better diff results when assertions fail.
+	 *
+	 * @param string $json
+	 * @return string
+	 */
+	private function normalizeJson($json)
+	{
+		return json_encode(json_decode($json), JSON_PRETTY_PRINT);
 	}
 	
 	public function provideAllCases() {
@@ -19,7 +32,7 @@ class OutputTest extends SwaggerGen_TestCase
 		
 		foreach (glob(__DIR__ . '/*', GLOB_ONLYDIR) as $dir) {					
 			$path = realpath($dir);					
-			$json = json_encode(json_decode(file_get_contents($path . '/expected.json')));
+			$json = $this->normalizeJson(file_get_contents($path . '/expected.json'));
 			
 			$files = array();
 			if (file_exists($path . '/source.php')) {


### PR DESCRIPTION
1. Switched to built-in phpunit json-equals assertion, which brings a number of improvements, namely:
    * Both json strings are validated to be valid json
    * Order or the object properties no longer matters

2. Added pretty-printing for json, which improves failure output. Whereas previously failed assertion would output entire json documents as different, now the output will focus on actual semantic changes, highlighting differences much more precisely.