### PR TITLE
Wrap ref properties that has readonly/description into allOf

### DIFF
--- a/SwaggerGen/Swagger/Type/Property.php
+++ b/SwaggerGen/Swagger/Type/Property.php
@@ -113,7 +113,22 @@ class Property extends \SwaggerGen\Swagger\AbstractObject
 
 	public function toArray()
 	{
-		return self::arrayFilterNull(array_merge($this->Type->toArray(), array(
+		// Reference + readonly/description result in allOf construct
+		// as it's semantically the same and that's what swagger tools
+		// like swagger-ui can understand
+		$requiresWrap =
+			$this->Type instanceof \SwaggerGen\Swagger\Type\ReferenceObjectType
+			&& (!empty($this->description) || !is_null($this->readOnly));
+
+		$valueType = $this->Type->toArray();
+
+		if ($requiresWrap) {
+			$valueType = array(
+				"allOf" => array($valueType),
+			);
+		}
+
+		return self::arrayFilterNull(array_merge($valueType, array(
 					'description' => empty($this->description) ? null : $this->description,
                     'readOnly' => $this->readOnly
 								), parent::toArray()));

--- a/tests/output/readonly ref property/expected.json
+++ b/tests/output/readonly ref property/expected.json
@@ -1,0 +1,61 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "undefined",
+        "version": "0"
+    },
+	"host": "example.com",
+	"basePath": "\/base",
+    "paths": {
+        "\/customers": {
+            "get": {
+                "tags": [
+                    "Test"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#\/definitions\/Person"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "Address": {
+            "type": "object",
+            "required": [
+                "city"
+            ],
+            "properties": {
+                "city": {
+                    "type": "string"
+                }
+            }
+        },
+        "Person": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "home": {
+                    "allOf": [
+                        { "$ref": "#\/definitions\/Address" }
+                    ],
+                    "readOnly" : true
+                }
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "Test"
+        }
+    ]
+}

--- a/tests/output/readonly ref property/source.txt
+++ b/tests/output/readonly ref property/source.txt
@@ -1,0 +1,9 @@
+model Address
+property string city
+model Person
+property string name
+property! Address home
+api Test
+endpoint /customers
+method GET
+response 200 Person


### PR DESCRIPTION
When you have a ref property with either `readonly` or `description` set Swagger UI complains that it will ignore those attributes. Even though OAS2 spec does not actually forbids this case, other tools may also get confused, as official Swagger tools might be looked at as a reference implementation.

The way to fix this (and keep the same semantic) is to wrap the reference into `allOf` construct:
```
    "home": {
	"allOf": [
	    { "$ref": "#\/definitions\/Address" }
	],
	"readOnly" : true
    }
```