### PR TITLE
allOf support

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,12 +556,22 @@ You can specify the URL, email address and name in any order you want.
 The URL and email address will be automatically detected, the name will consist
 of all text remaining (properly separated with whitespace).
 
-### `definintion` *`name`* &rArr; Schema
+### `definintion` *`name` [type]* &rArr; Schema
 Start definition of a Schema using the reference name specified. 
 
 Definitions can be specified as read only using exclamation point at the end of
 the definition command. E.g. `definition! user` will create a user model that
 will appear in GET responses and be omitted from POST, PUT, and PATCH requests.
+
+When no type is specified, `definition` creates an `object` definition. You can
+specify `type` to create definitions for other types:
+
+    definition PositiveInteger integer[1,>
+    
+    definition ArrayOfString array(string)
+
+See the chapter on  **Parameter definitions** for a detailed description of all
+the possible definition types.
 
 alias: `model` (for historical reasons)
 
@@ -842,6 +852,9 @@ Alternative short-hand notation:
 *	**`property` *definition name*** Add a required property.
 *	**`property?` *definition name*** Add an optional property.
 *   **`property!` *definition name*** Add a read only property.
+*   **`discriminator` *propertyName*** Sets the property as a discriminator.
+	The property must be required (could not be read only nor optional), but
+	you can define it later.
 
 ### Examples
 *	**`object(age:int[18,25>)`** An object containing a single key `age` with
@@ -850,6 +863,25 @@ Alternative short-hand notation:
 	optional `name` string, where the value must be atleast two characters
 	long.
 *	**`object()[4,8]`** An object containing four to eight unknown properties.
+
+## allof
+Intersection type (data must satisfy all base types). May be used for type
+composition or to implement inheritance (in conjunction with `discriminator`).
+Could also be used to refine the constraints imposed by the base type.
+
+    allof(definition)
+
+*	definition: a comma-separated list of base types, either as inline
+	definitions or references to another definition
+
+### Commands
+*   **`item` *type*** Add the type to the list of allOf types
+
+### Examples
+*   **`allOf(DataModel,IdModel)`** type composition: effectively creates
+	DataWithId type.
+*   **`allOf(ModelWithOptionalName,object(name:string))`** type refinement:
+	effectively makes `name` property required.
 
 ## enum
 Special type of string which is limited to one of a number of predefined values.

--- a/SwaggerGen/Swagger/Schema.php
+++ b/SwaggerGen/Swagger/Schema.php
@@ -14,33 +14,6 @@ namespace SwaggerGen\Swagger;
 class Schema extends AbstractDocumentableObject implements IDefinition
 {
 
-	private static $classTypes = array(
-		'integer' => 'Integer',
-		'int' => 'Integer',
-		'int32' => 'Integer',
-		'int64' => 'Integer',
-		'long' => 'Integer',
-		'float' => 'Number',
-		'double' => 'Number',
-		'string' => 'String',
-		'uuid' => 'StringUuid',
-		'byte' => 'String',
-		'binary' => 'String',
-		'password' => 'String',
-		'enum' => 'String',
-		'boolean' => 'Boolean',
-		'bool' => 'Boolean',
-		'array' => 'Array',
-		'csv' => 'Array',
-		'ssv' => 'Array',
-		'tsv' => 'Array',
-		'pipes' => 'Array',
-		'date' => 'Date',
-		'datetime' => 'Date',
-		'date-time' => 'Date',
-		'object' => 'Object',
-	);
-
 	/**
 	 * @var string
 	 */
@@ -69,26 +42,7 @@ class Schema extends AbstractDocumentableObject implements IDefinition
 		if ($this->getSwagger()->hasDefinition($definition)) {
 			$this->type = new Type\ReferenceObjectType($this, $definition);
 		} else {
-			// Parse regex		
-			$match = array();
-			if (preg_match('/^([a-z]+)/i', $definition, $match) === 1) {
-				// recognized format
-			} elseif (preg_match('/^(\[)(?:.*?)\]$/i', $definition, $match) === 1) {
-				$match[1] = 'array';
-			} elseif (preg_match('/^(\{)(?:.*?)\}$/i', $definition, $match) === 1) {
-				$match[1] = 'object';
-			} else {
-				throw new \SwaggerGen\Exception("Unparseable schema type definition: '{$items}'");
-			}			
-			$format = strtolower($match[1]);
-			// Internal type if type known and not overwritten by definition
-			if (isset(self::$classTypes[$format])) {
-				$type = self::$classTypes[$format];
-				$class = "SwaggerGen\\Swagger\\Type\\{$type}Type";
-				$this->type = new $class($this, $definition);
-			} else {
-				$this->type = new Type\ReferenceObjectType($this, $definition);
-			}		
+			$this->type = Type\AbstractType::typeFactory($this, $definition);
 		}
 
 		$this->description = $description;

--- a/SwaggerGen/Swagger/Swagger.php
+++ b/SwaggerGen/Swagger/Swagger.php
@@ -145,14 +145,19 @@ class Swagger extends AbstractDocumentableObject
             case 'model!':
 			case 'definition':
             case 'definition!':
-				$definition = new Schema($this);
-				if(substr($command, -1) === '!') {
-				    $definition->setReadOnly();
-                }
 				$name = self::wordShift($data);
 				if (empty($name)) {
 					throw new \SwaggerGen\Exception('Missing definition name');
 				}
+				$typeDef = $data;
+				if (empty($typeDef)) {
+					$typeDef = 'object';
+				}
+
+				$definition = new Schema($this, $typeDef);
+				if(substr($command, -1) === '!') {
+				    $definition->setReadOnly();
+                }
 				$this->definitions[$name] = $definition;
 				return $definition;
 

--- a/SwaggerGen/Swagger/Swagger.php
+++ b/SwaggerGen/Swagger/Swagger.php
@@ -149,7 +149,7 @@ class Swagger extends AbstractDocumentableObject
 				if (empty($name)) {
 					throw new \SwaggerGen\Exception('Missing definition name');
 				}
-				$typeDef = $data;
+				$typeDef = self::wordShift($data);
 				if (empty($typeDef)) {
 					$typeDef = 'object';
 				}

--- a/SwaggerGen/Swagger/Type/AbstractType.php
+++ b/SwaggerGen/Swagger/Type/AbstractType.php
@@ -114,7 +114,7 @@ abstract class AbstractType extends \SwaggerGen\Swagger\AbstractObject
 		} elseif (preg_match('/^(\{)(?:.*?)\}$/i', $definition, $match) === 1) {
 			$match[1] = 'object';
 		} else {
-			throw new \SwaggerGen\Exception("Unparseable schema type definition: '{$items}'");
+			throw new \SwaggerGen\Exception("Unparseable schema type definition: '{$definition}'");
 		}
 		$format = strtolower($match[1]);
 		// Internal type if type known and not overwritten by definition

--- a/SwaggerGen/Swagger/Type/AbstractType.php
+++ b/SwaggerGen/Swagger/Type/AbstractType.php
@@ -45,6 +45,7 @@ abstract class AbstractType extends \SwaggerGen\Swagger\AbstractObject
 		'datetime' => 'Date',
 		'date-time' => 'Date',
 		'object' => 'Object',
+		'refobject' => 'ReferenceObject',
 		'allof' => 'AllOf',
 	);
 

--- a/SwaggerGen/Swagger/Type/AbstractType.php
+++ b/SwaggerGen/Swagger/Type/AbstractType.php
@@ -60,6 +60,52 @@ abstract class AbstractType extends \SwaggerGen\Swagger\AbstractObject
 	}
 
 	/**
+	 * @param string $list
+	 * @return array
+	 */
+	protected static function parseList($list)
+	{
+		$ret = array();
+		while ($item = self::parseListItem($list)) {
+			$ret[] = $item;
+		}
+		return $ret;
+	}
+
+	/**
+	 * Extract an item from a comma-separated list of items.
+	 *
+	 * i.e. `a(x(x,x)),b(x)` returns `a(x(x,x))` and changes `$list` into `b(x)`.
+	 * Note: brace nesting is not checked, e.g. `a{b(})` is a valid list item.
+	 *
+	 * @param string $list the list to parse
+	 * @return string the extracted item
+	 */
+	protected static function parseListItem(&$list)
+	{
+		$item = '';
+
+		$depth = 0;
+		$index = 0;
+		while ($index < strlen($list)) {
+			$c = $list{$index++};
+
+			if (strpos('{([<', $c) !== false) {
+				++$depth;
+			} elseif (strpos('})]>', $c) !== false) {
+				--$depth;
+			} elseif ($c === ',' && $depth === 0) {
+				break;
+			}
+
+			$item .= $c;
+		}
+		$list = substr($list, $index);
+
+		return $item;
+	}
+
+	/**
 	 * @var string $definition
 	 */
 	public function __construct(\SwaggerGen\Swagger\AbstractObject $parent, $definition)

--- a/SwaggerGen/Swagger/Type/AbstractType.php
+++ b/SwaggerGen/Swagger/Type/AbstractType.php
@@ -103,7 +103,7 @@ abstract class AbstractType extends \SwaggerGen\Swagger\AbstractObject
 								), parent::toArray()));
 	}
 
-	public static function typeFactory($parent, $definition)
+	public static function typeFactory($parent, $definition, $error = "Unparseable schema type definition: '%s'")
 	{
 		// Parse regex
 		$match = array();
@@ -114,7 +114,7 @@ abstract class AbstractType extends \SwaggerGen\Swagger\AbstractObject
 		} elseif (preg_match('/^(\{)(?:.*?)\}$/i', $definition, $match) === 1) {
 			$match[1] = 'object';
 		} else {
-			throw new \SwaggerGen\Exception("Unparseable schema type definition: '{$definition}'");
+			throw new \SwaggerGen\Exception(sprintf($error, $definition));
 		}
 		$format = strtolower($match[1]);
 		// Internal type if type known and not overwritten by definition

--- a/SwaggerGen/Swagger/Type/AllOfType.php
+++ b/SwaggerGen/Swagger/Type/AllOfType.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace SwaggerGen\Swagger\Type;
+
+/**
+ * allOf compound type
+ *
+ * @package    SwaggerGen
+ * @author     Bruce Weirdan <weirdan@gmail.com>
+ * @copyright  2014-2015 Martijn van der Lee
+ * @license    https://opensource.org/licenses/MIT MIT
+ */
+class AllOfType extends AbstractType
+{
+	private $allOfItems = array();
+	private $mostRecentItem;
+	protected function parseDefinition($definition)
+	{
+		$pattern = self::REGEX_START . 'allOf' . self::REGEX_CONTENT . self::REGEX_END;
+		$inlineDef = '';
+		if (preg_match($pattern, $definition, $matches)) {
+			if (isset($matches[1])) {
+				$inlineDef = $matches[1];
+			}
+		}
+		if ($inlineDef) {
+			foreach ($this->parseList($inlineDef) as $item) {
+				$this->handleCommand('item', $item);
+			}
+		}
+	}
+
+	/**
+	 * @param string $list
+	 * @return string
+	 * @todo remove duplication between this method and ObjectType::extract_property()
+	 */
+	private function getItem(&$list)
+	{
+		static $openingBraces = array('(', '[', '{', '<',);
+		static $closingBraces = array(')', ']', '}', '>');
+
+		$depth = 0;
+		$index = 0;
+		$item = '';
+
+		while ($index < strlen($list)) {
+			$c = $list{$index};
+			$index++;
+			if (in_array($c, $openingBraces)) {
+				$depth++;
+			} elseif (in_array($c, $closingBraces)) {
+				$depth--;
+			} elseif ($c === ',' && !$depth) {
+				break;
+			}
+			$item .= $c;
+		}
+		$list = substr($list, $index);
+		return $item;
+	}
+
+	/**
+	 * @param string $list
+	 * @return array
+	 */
+	private function parseList($list)
+	{
+		$ret = array();
+		while ($item = $this->getItem($list)) {
+			$ret[] = $item;
+		}
+		return $ret;
+	}
+
+	public function handleCommand($command, $data = null)
+	{
+		switch ($command) {
+			case 'ref':
+			case 'inline':
+			case 'item':
+				$this->mostRecentItem = self::typeFactory($this, $data);
+				$this->allOfItems[] = $this->mostRecentItem;
+				return $this;
+		}
+		if (isset($this->mostRecentItem)) {
+			if ($this->mostRecentItem->handleCommand($command, $data)) {
+				return $this;
+			}
+		}
+		return parent::handleCommand($command, $data);
+	}
+
+	public function toArray()
+	{
+		$allOf = array();
+		foreach ($this->allOfItems as $item) {
+			$allOf[] = $item->toArray();
+		}
+		return self::arrayFilterNull(array_merge(array(
+			'allOf' => $allOf,
+		), parent::toArray()));
+	}
+}

--- a/SwaggerGen/Swagger/Type/AllOfType.php
+++ b/SwaggerGen/Swagger/Type/AllOfType.php
@@ -16,7 +16,7 @@ class AllOfType extends AbstractType
 	private $mostRecentItem;
 	protected function parseDefinition($definition)
 	{
-		$pattern = self::REGEX_START . 'allOf' . self::REGEX_CONTENT . self::REGEX_END;
+		$pattern = self::REGEX_START . 'allof' . self::REGEX_CONTENT . self::REGEX_END;
 		$inlineDef = '';
 		if (preg_match($pattern, $definition, $matches)) {
 			if (isset($matches[1])) {

--- a/SwaggerGen/Swagger/Type/AllOfType.php
+++ b/SwaggerGen/Swagger/Type/AllOfType.php
@@ -33,8 +33,6 @@ class AllOfType extends AbstractType
 	public function handleCommand($command, $data = null)
 	{
 		switch ($command) {
-			case 'ref':
-			case 'inline':
 			case 'item':
 				$this->mostRecentItem = self::typeFactory($this, $data);
 				$this->allOfItems[] = $this->mostRecentItem;

--- a/SwaggerGen/Swagger/Type/AllOfType.php
+++ b/SwaggerGen/Swagger/Type/AllOfType.php
@@ -30,49 +30,6 @@ class AllOfType extends AbstractType
 		}
 	}
 
-	/**
-	 * @param string $list
-	 * @return string
-	 * @todo remove duplication between this method and ObjectType::extract_property()
-	 */
-	private function getItem(&$list)
-	{
-		static $openingBraces = array('(', '[', '{', '<',);
-		static $closingBraces = array(')', ']', '}', '>');
-
-		$depth = 0;
-		$index = 0;
-		$item = '';
-
-		while ($index < strlen($list)) {
-			$c = $list{$index};
-			$index++;
-			if (in_array($c, $openingBraces)) {
-				$depth++;
-			} elseif (in_array($c, $closingBraces)) {
-				$depth--;
-			} elseif ($c === ',' && !$depth) {
-				break;
-			}
-			$item .= $c;
-		}
-		$list = substr($list, $index);
-		return $item;
-	}
-
-	/**
-	 * @param string $list
-	 * @return array
-	 */
-	private function parseList($list)
-	{
-		$ret = array();
-		while ($item = $this->getItem($list)) {
-			$ret[] = $item;
-		}
-		return $ret;
-	}
-
 	public function handleCommand($command, $data = null)
 	{
 		switch ($command) {

--- a/SwaggerGen/Swagger/Type/ArrayType.php
+++ b/SwaggerGen/Swagger/Type/ArrayType.php
@@ -15,32 +15,6 @@ class ArrayType extends AbstractType
 
 	const REGEX_ARRAY_CONTENT = '(?:(\[)(.*)\])?';
 
-	private static $classTypes = array(
-		'integer' => 'Integer',
-		'int' => 'Integer',
-		'int32' => 'Integer',
-		'int64' => 'Integer',
-		'long' => 'Integer',
-		'float' => 'Number',
-		'double' => 'Number',
-		'string' => 'String',
-		'uuid' => 'StringUuid',
-		'byte' => 'String',
-		'binary' => 'String',
-		'password' => 'String',
-		'enum' => 'String',
-		'boolean' => 'Boolean',
-		'bool' => 'Boolean',
-		'array' => 'Array',
-		'csv' => 'Array',
-		'ssv' => 'Array',
-		'tsv' => 'Array',
-		'pipes' => 'Array',
-		'date' => 'Date',
-		'datetime' => 'Date',
-		'date-time' => 'Date',
-		'object' => 'Object',
-	);
 	private static $collectionFormats = array(
 		'array' => 'csv',
 		'csv' => 'csv',
@@ -179,24 +153,7 @@ class ArrayType extends AbstractType
 			throw new \SwaggerGen\Exception("Empty items definition: '{$items}'");
 		}
 
-		$match = array();
-		if (preg_match('/^([a-z]+)/i', $items, $match) === 1) {
-			// recognized format
-		} elseif (preg_match('/^(\[)(?:.*?)\]$/i', $items, $match) === 1) {
-			$match[1] = 'array';
-		} elseif (preg_match('/^(\{)(?:.*?)\}$/i', $items, $match) === 1) {
-			$match[1] = 'object';
-		} else {
-			throw new \SwaggerGen\Exception("Unparseable items definition: '{$items}'");
-		}
-		$format = strtolower($match[1]);
-		if (isset(self::$classTypes[$format])) {
-			$type = self::$classTypes[$format];
-			$typeClass = "SwaggerGen\\Swagger\\Type\\{$type}Type";
-			return new $typeClass($this, $items);
-		}
-
-		return new ReferenceObjectType($this, $items);
+		return self::typeFactory($this, $items, "Unparseable items definition: '%s'");
 	}
 
 	public function __toString()

--- a/SwaggerGen/Swagger/Type/ObjectType.php
+++ b/SwaggerGen/Swagger/Type/ObjectType.php
@@ -23,6 +23,7 @@ class ObjectType extends AbstractType
 
 	private $minProperties = null;
 	private $maxProperties = null;
+	private $discriminator = null;
 	private $required = array();
 
 	/**
@@ -108,6 +109,9 @@ class ObjectType extends AbstractType
 	{
 		switch (strtolower($command)) {
 			// type name description...
+			case 'discriminator':
+				$this->discriminator = $data;
+				return $this;
 			case 'property':
 			case 'property?':
 			case 'property!':
@@ -172,6 +176,7 @@ class ObjectType extends AbstractType
 					'properties' => self::objectsToArray($this->properties),
 					'minProperties' => $this->minProperties,
 					'maxProperties' => $this->maxProperties,
+					'discriminator' => $this->discriminator,
 								), parent::toArray()));
 	}
 

--- a/SwaggerGen/Swagger/Type/ObjectType.php
+++ b/SwaggerGen/Swagger/Type/ObjectType.php
@@ -66,7 +66,7 @@ class ObjectType extends AbstractType
 	{
 		if (!empty($match[2])) {
 			do {
-				if (($property = self::extract_property($match[2])) !== '') {
+				if (($property = self::parseListItem($match[2])) !== '') {
 					$prop_match = array();
 					if (preg_match(self::REGEX_PROP_START . self::REGEX_PROP_NAME . self::REGEX_PROP_REQUIRED . self::REGEX_PROP_ASSIGN . self::REGEX_PROP_DEFINITION . self::REGEX_PROP_END, $property, $prop_match) !== 1) {
 						throw new \SwaggerGen\Exception("Unparseable property definition: '{$property}'");
@@ -209,39 +209,6 @@ class ObjectType extends AbstractType
 	public function __toString()
 	{
 		return __CLASS__;
-	}
-
-	/**
-	 * Extract a property from a comma-separated list of properties.
-	 *
-	 * i.e. `a(x(x,x)),b(x)` returns `a(x(x,x))` and changes `$properties` into `b(x)`.
-	 *
-	 * @param string $properties string variable
-	 * @return string the extracted string
-	 */
-	private static function extract_property(&$properties)
-	{
-		$property = '';
-
-		$depth = 0;
-		$index = 0;
-		while ($index < strlen($properties)) {
-			$character = $properties{$index++};
-
-			if (strpos('{([<', $character) !== false) {
-				++$depth;
-			} elseif (strpos('})]>', $character) !== false) {
-				--$depth;
-			} elseif ($character === ',' && $depth === 0) {
-				break;
-			}
-
-			$property .= $character;
-		}
-
-		$properties = substr($properties, $index);
-
-		return $property;
 	}
 
 }

--- a/SwaggerGen/Swagger/Type/Property.php
+++ b/SwaggerGen/Swagger/Type/Property.php
@@ -13,35 +13,6 @@ namespace SwaggerGen\Swagger\Type;
 class Property extends \SwaggerGen\Swagger\AbstractObject
 {
 
-	private static $classTypes = array(
-		'integer' => 'Integer',
-		'int' => 'Integer',
-		'int32' => 'Integer',
-		'int64' => 'Integer',
-		'long' => 'Integer',
-		'float' => 'Number',
-		'double' => 'Number',
-		'string' => 'String',
-		'uuid' => 'StringUuid',
-		'byte' => 'String',
-		'binary' => 'String',
-		'password' => 'String',
-		'enum' => 'String',
-		'boolean' => 'Boolean',
-		'bool' => 'Boolean',
-		'array' => 'Array',
-		'csv' => 'Array',
-		'ssv' => 'Array',
-		'tsv' => 'Array',
-		'pipes' => 'Array',
-		'multi' => 'Array',
-		'date' => 'Date',
-		'datetime' => 'Date',
-		'date-time' => 'Date',
-		'object' => 'Object',
-		'refobject' => 'ReferenceObject',
-	);
-
 	/**
 	 * Description of this property
 	 * @var string

--- a/SwaggerGen/Swagger/Type/Property.php
+++ b/SwaggerGen/Swagger/Type/Property.php
@@ -71,27 +71,7 @@ class Property extends \SwaggerGen\Swagger\AbstractObject
 	public function __construct(\SwaggerGen\Swagger\AbstractObject $parent, $definition, $description = null, $readOnly = null)
 	{
 		parent::__construct($parent);
-
-		// Parse regex
-		$match = array();
-		if (preg_match('/^([a-z]+)/i', $definition, $match) === 1) {
-			// recognized format
-		} elseif (preg_match('/^(\[)(?:.*?)\]$/i', $definition, $match) === 1) {
-			$match[1] = 'array';
-		} elseif (preg_match('/^(\{)(?:.*?)\}$/i', $definition, $match) === 1) {
-			$match[1] = 'object';
-		} else {
-			throw new \SwaggerGen\Exception("Not a property: '{$definition}'");
-		}
-		$format = strtolower($match[1]);
-		if (isset(self::$classTypes[$format])) {
-			$type = self::$classTypes[$format];
-			$class = "SwaggerGen\\Swagger\\Type\\{$type}Type";
-			$this->Type = new $class($this, $definition);
-		} else {
-			$this->Type = new \SwaggerGen\Swagger\Type\ReferenceObjectType($this, $definition);
-		}
-
+		$this->Type = AbstractType::typeFactory($this, $definition, "Not a property: '%s'");
 		$this->description = $description;
 		$this->readOnly = $readOnly;
 	}

--- a/TODO.md
+++ b/TODO.md
@@ -37,7 +37,8 @@
 *	Set type (array of enumerated strings; can force unique?)
 *	License: full/formatted names
 *	Date(-time) format helpers; if no timezone, add 'Z'. Use PHP Date parser.
-*	Support object `additionalProperties` and `allOf`
+*	Support object `additionalProperties`
+*	Implement `allOf` annotation
 *	Shortcut "get", "put", etc. operation methods as proper commands.
 *	Force correct defaults on models. [See issue](https://github.com/swagger-api/swagger-ui/issues/2436)
 *	Implement `required` in `Schema` for object properties. (JSON Schema, p.12)

--- a/tests/Swagger/Type/ObjectTypeTest.php
+++ b/tests/Swagger/Type/ObjectTypeTest.php
@@ -397,4 +397,44 @@ class ObjectTypeTest extends SwaggerGen_TestCase
 				. ',"tags":[{"name":"Test"}]}', json_encode($array, JSON_NUMERIC_CHECK));
 	}
 
+	public function testAddingOptionalPropertyFailsWhenItIsDiscriminator()
+	{
+		$object = new SwaggerGen\Swagger\Type\ObjectType($this->parent, 'object');
+		$object->handleCommand('discriminator', 'type');
+		$this->expectException('\SwaggerGen\Exception', "Discriminator must be a required property, property 'type' is not required");
+		$object->handleCommand('property?', 'string type');
+	}
+
+	public function testAddingReadonlyPropertyFailsWhenItIsDiscriminator()
+	{
+		$object = new SwaggerGen\Swagger\Type\ObjectType($this->parent, 'object');
+		$object->handleCommand('discriminator', 'type');
+		$this->expectException('\SwaggerGen\Exception', "Discriminator must be a required property, property 'type' is not required");
+		$object->handleCommand('property!', 'string type');
+	}
+
+	public function testDiscriminatingOnOptionalPropertyFails()
+	{
+		$object = new SwaggerGen\Swagger\Type\ObjectType($this->parent, 'object');
+		$object->handleCommand('property?', 'string type');
+		$this->expectException('\SwaggerGen\Exception', "Discriminator must be a required property, property 'type' is not required");
+		$object->handleCommand('discriminator', 'type');
+	}
+
+	public function testDiscriminatingOnReadonlyPropertyFails()
+	{
+		$object = new SwaggerGen\Swagger\Type\ObjectType($this->parent, 'object');
+		$object->handleCommand('property!', 'string type');
+		$this->expectException('\SwaggerGen\Exception', "Discriminator must be a required property, property 'type' is not required");
+		$object->handleCommand('discriminator', 'type');
+	}
+
+	public function testSettingAnotherDiscriminatorFails()
+	{
+		$object = new SwaggerGen\Swagger\Type\ObjectType($this->parent, 'object');
+		$object->handleCommand('discriminator', 'type');
+		$this->expectException('\SwaggerGen\Exception', "Discriminator may only be set once, trying to change it from 'type' to 'petType'");
+		$object->handleCommand('discriminator', 'petType');
+	}
+
 }

--- a/tests/output/allOf in array/expected.json
+++ b/tests/output/allOf in array/expected.json
@@ -1,0 +1,77 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "undefined",
+    "version": "0"
+  },
+  "host": "example.com",
+  "basePath": "/base",
+  "paths": {
+    "/object": {
+      "get": {
+        "tags": [
+          "Test"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/someObject"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+      "objectWithArrayWithItems": {
+          "type": "object",
+          "required": ["positiveArray"],
+          "properties": {
+              "positiveArray" : {
+                  "type": "array",
+                  "items": {
+                      "allOf": [
+                          {"$ref": "#/definitions/IntegerNumber"},
+                          {
+                              "type": "integer",
+                              "format": "int32",
+                              "exclusiveMaximum": true,
+                              "minimum": 1
+                          }
+                      ]
+                  }
+              }
+          }
+      },
+      "someObject": {
+          "type": "object",
+          "required": ["positiveArray"],
+          "properties": {
+              "positiveArray" : {
+                  "type": "array",
+                  "items": {
+                      "allOf": [
+                          {"$ref": "#/definitions/IntegerNumber"},
+                          {
+                              "type": "integer",
+                              "format": "int32",
+                              "exclusiveMaximum": true,
+                              "minimum": 1
+                          }
+                      ]
+                  }
+              }
+          }
+      },
+      "IntegerNumber": {
+          "type": "integer",
+          "format": "int32"
+      }
+  },
+  "tags": [
+    {
+      "name": "Test"
+    }
+  ]
+}

--- a/tests/output/allOf in array/source.txt
+++ b/tests/output/allOf in array/source.txt
@@ -6,7 +6,7 @@ property array(allOf(IntegerNumber,integer[1,>)) positiveArray
 model objectWithArrayWithItems
 property array positiveArray
 items allOf(IntegerNumber)
-inline integer[1,>
+item integer[1,>
 
 api Test
 endpoint /object

--- a/tests/output/allOf in array/source.txt
+++ b/tests/output/allOf in array/source.txt
@@ -1,0 +1,14 @@
+model IntegerNumber integer
+
+model someObject
+property array(allOf(IntegerNumber,integer[1,>)) positiveArray
+
+model objectWithArrayWithItems
+property array positiveArray
+items allOf(IntegerNumber)
+inline integer[1,>
+
+api Test
+endpoint /object
+method GET
+response 200 someObject

--- a/tests/output/allOf in model top level/expected.json
+++ b/tests/output/allOf in model top level/expected.json
@@ -1,0 +1,271 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "undefined",
+    "version": "0"
+  },
+  "host": "example.com",
+  "basePath": "/base",
+  "paths": {
+    "/customers": {
+      "get": {
+        "tags": [
+          "Test"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Customer"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Id": {
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uuid",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        }
+      }
+    },
+    "CustomerRef": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Id"
+        },
+        {
+          "discriminator": "type",
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Customer",
+                "CustomerRef",
+                "Person",
+                "PersonRef",
+                "Company",
+                "CompanyRef"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "CustomerData": {
+      "type": "object",
+      "discriminator": "type",
+      "required": [
+        "address",
+        "type"
+      ],
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Customer",
+            "CustomerData",
+            "Person",
+            "PersonData",
+            "Company",
+            "CompanyData"
+          ]
+        }
+      }
+    },
+    "Customer": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/CustomerRef"
+        },
+        {
+          "$ref": "#/definitions/CustomerData"
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Customer",
+                "Person",
+                "Company"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "PersonRef": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/CustomerRef"
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Person",
+                "PersonRef"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "PersonData": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/CustomerData"
+        },
+        {
+          "type": "object",
+          "required": [
+            "firstName",
+            "lastName",
+            "type"
+          ],
+          "properties": {
+            "firstName": {
+              "type": "string"
+            },
+            "lastName": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "Person",
+                "PersonData"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Person": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/PersonRef"
+        },
+        {
+          "$ref": "#/definitions/PersonData"
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Person"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "CompanyRef": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/CustomerRef"
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Company",
+                "CompanyRef"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "CompanyData": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/CustomerData"
+        },
+        {
+          "type": "object",
+          "required": [
+            "companyName",
+            "type"
+          ],
+          "properties": {
+            "companyName": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": [
+                "Company",
+                "CompanyData"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "Company": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/CompanyRef"
+        },
+        {
+          "$ref": "#/definitions/CompanyData"
+        },
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Company"
+              ]
+            }
+          }
+        }
+      ]
+    }
+  },
+  "tags": [
+    {
+      "name": "Test"
+    }
+  ]
+}

--- a/tests/output/allOf in model top level/source.txt
+++ b/tests/output/allOf in model top level/source.txt
@@ -1,0 +1,63 @@
+model Id object(id:uuid)
+
+model CustomerRef allOf
+ref Id
+inline object
+discriminator type
+property string type
+enum Customer CustomerRef Person PersonRef Company CompanyRef
+
+model CustomerData object
+discriminator type
+property string address
+property string type
+enum Customer CustomerData Person PersonData Company CompanyData
+
+model Customer allOf
+ref CustomerRef
+ref CustomerData
+inline object
+property string type
+enum Customer Person Company
+
+model PersonRef allOf
+ref CustomerRef
+inline object
+property string type
+enum Person PersonRef 
+
+model PersonData allOf
+ref CustomerData
+inline object
+property string firstName
+property string lastName
+property string type
+enum Person PersonData
+
+model Person allOf
+ref PersonRef
+ref PersonData
+inline object
+property string type
+enum Person
+
+model CompanyRef allOf(CustomerRef)
+inline object
+property string type
+enum Company CompanyRef
+
+model CompanyData allOf
+ref CustomerData
+inline object(companyName:string)
+property string type
+enum Company CompanyData
+
+model Company allOf(CompanyRef,CompanyData)
+inline object
+property string type
+enum Company
+
+api Test
+endpoint /customers
+method GET
+response 200 Customer

--- a/tests/output/allOf in model top level/source.txt
+++ b/tests/output/allOf in model top level/source.txt
@@ -1,8 +1,8 @@
 model Id object(id:uuid)
 
 model CustomerRef allOf
-ref Id
-inline object
+item Id
+item object
 discriminator type
 property string type
 enum Customer CustomerRef Person PersonRef Company CompanyRef
@@ -14,46 +14,46 @@ property string type
 enum Customer CustomerData Person PersonData Company CompanyData
 
 model Customer allOf
-ref CustomerRef
-ref CustomerData
-inline object
+item CustomerRef
+item CustomerData
+item object
 property string type
 enum Customer Person Company
 
 model PersonRef allOf
-ref CustomerRef
-inline object
+item CustomerRef
+item object
 property string type
 enum Person PersonRef 
 
 model PersonData allOf
-ref CustomerData
-inline object
+item CustomerData
+item object
 property string firstName
 property string lastName
 property string type
 enum Person PersonData
 
 model Person allOf
-ref PersonRef
-ref PersonData
-inline object
+item PersonRef
+item PersonData
+item object
 property string type
 enum Person
 
 model CompanyRef allOf(CustomerRef)
-inline object
+item object
 property string type
 enum Company CompanyRef
 
 model CompanyData allOf
-ref CustomerData
-inline object(companyName:string)
+item CustomerData
+item object(companyName:string)
 property string type
 enum Company CompanyData
 
 model Company allOf(CompanyRef,CompanyData)
-inline object
+item object
 property string type
 enum Company
 

--- a/tests/output/allOf in property/expected.json
+++ b/tests/output/allOf in property/expected.json
@@ -1,0 +1,53 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "undefined",
+    "version": "0"
+  },
+  "host": "example.com",
+  "basePath": "/base",
+  "paths": {
+    "/enum": {
+      "get": {
+        "tags": [
+          "Test"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/UsingEnum"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+      "WideEnum": {
+          "type": "string",
+          "enum": ["1", "2", "3"]
+      },
+      "UsingEnum": {
+          "type" : "object",
+          "required": ["enumProperty"],
+          "properties": {
+              "enumProperty" : {
+                  "allOf": [
+                    {"$ref" : "#/definitions/WideEnum"},
+                    {
+                        "type": "string",
+                        "enum": ["2"]
+                    }
+                  ]
+              }
+          }
+      }
+
+  },
+  "tags": [
+    {
+      "name": "Test"
+    }
+  ]
+}

--- a/tests/output/allOf in property/source.txt
+++ b/tests/output/allOf in property/source.txt
@@ -1,0 +1,11 @@
+model WideEnum enum(1,2,3)
+
+model UsingEnum
+property allOf(WideEnum) enumProperty
+inline string
+enum 2
+
+api Test
+endpoint /enum
+method GET
+response 200 UsingEnum

--- a/tests/output/allOf in property/source.txt
+++ b/tests/output/allOf in property/source.txt
@@ -2,7 +2,7 @@ model WideEnum enum(1,2,3)
 
 model UsingEnum
 property allof(WideEnum) enumProperty
-inline string
+item string
 enum 2
 
 api Test

--- a/tests/output/allOf in property/source.txt
+++ b/tests/output/allOf in property/source.txt
@@ -1,7 +1,7 @@
 model WideEnum enum(1,2,3)
 
 model UsingEnum
-property allOf(WideEnum) enumProperty
+property allof(WideEnum) enumProperty
 inline string
 enum 2
 

--- a/tests/output/allOf in response/expected.json
+++ b/tests/output/allOf in response/expected.json
@@ -1,0 +1,68 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "undefined",
+    "version": "0"
+  },
+  "host": "example.com",
+  "basePath": "/base",
+  "paths": {
+    "/me": {
+      "get": {
+        "tags": [
+          "Test"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/Person"
+                },
+                {
+                  "$ref": "#/definitions/Id"
+                }
+              ]
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Person": {
+      "type": "object",
+      "required": [
+        "firstName",
+        "lastName"
+      ],
+      "properties": {
+        "firstName": {
+          "type": "string"
+        },
+        "lastName": {
+          "type": "string"
+        }
+      }
+    },
+    "Id": {
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uuid",
+          "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Test"
+    }
+  ]
+}

--- a/tests/output/allOf in response/source.txt
+++ b/tests/output/allOf in response/source.txt
@@ -1,0 +1,11 @@
+model Id object
+property uuid id
+
+model Person object
+property string firstName 
+property string lastName 
+
+api Test
+endpoint /me
+method GET
+response 200 allOf(Person,Id)


### PR DESCRIPTION
allOf is a compound type that can be used wherever type can be used (so far tested in top-level models, but theoretically it should work in other places too).

Both inline (`allOf(ModelName,object(fieldName:type)`) and command sequence definitions are supported, including mixed definitions:
```
definition ModelWithId allOf(Model,Id)

definition AnotherModelWithId allOf
item Model
item Id
item object
property string modelProp

definition YetAnotherModelWithId allOf(Model)
item Id
```
For now there's no support in annotations parser (because I do not use swaggergen annotations), but that should be trivial to add I suppose.