### PR TITLE
Assert on exception messages

### DIFF
--- a/tests/Swagger/ResponseTest.php
+++ b/tests/Swagger/ResponseTest.php
@@ -227,7 +227,7 @@ class ResponseTest extends SwaggerGen_TestCase
 
 		$this->assertInstanceOf('\SwaggerGen\Swagger\Response', $object);
 
-		$this->expectException('\SwaggerGen\Exception', "Missing content example `Foo`");
+		$this->expectException('\SwaggerGen\Exception', "Missing content for example `Foo`");
 
 		$object->handleCommand('example', 'Foo');
 	}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,9 +15,18 @@ if (!class_exists('PHPUnit\Framework\TestCase') && class_exists('PHPUnit_Framewo
 class SwaggerGen_TestCase extends PHPUnit\Framework\TestCase
 {
 
-	public function expectException($exception)
+	public function expectException($exception, $message = '')
 	{
-		return method_exists($this, 'setExpectedException') ? self::setExpectedException($exception) : parent::expectException($exception);
+		// while setExpectedException accepts message to assert on, expectException does not
+		if (method_exists($this, 'setExpectedException')) {
+			$ret = $this->setExpectedException($exception, $message);
+		} else {
+			$ret = parent::expectException($exception);
+			if ($message !== '') {
+				parent::expectExceptionMessage($message);
+			}
+		}
+		return $ret;
 	}
 
 }


### PR DESCRIPTION
Many tests use `expectException('exceptionClass', 'message')` pattern, however exception messages were previously ignored.