### PR TITLE
Make tests compatible with PHPUnit 7+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,11 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - hhvm
 matrix:
     include:
       - php: "5.3"
         dist: precise
     allow_failures:
-      - php: hhvm            
+      - php: hhvm

--- a/tests/Base/PHPUnit5.php
+++ b/tests/Base/PHPUnit5.php
@@ -1,6 +1,6 @@
 <?php
 
-class Base_PHPUnit5 extends PHPUnit\Framework\TestCase
+class Base_PHPUnit5 extends PHPUnit_Framework_TestCase
 {
 	/**
 	 * @param string $exception

--- a/tests/Base/PHPUnit5.php
+++ b/tests/Base/PHPUnit5.php
@@ -1,0 +1,14 @@
+<?php
+
+class Base_PHPUnit5 extends PHPUnit\Framework\TestCase
+{
+	/**
+	 * @param string $exception
+	 * @param string $message
+	 * @return void
+	 */
+	public function expectException($exception, $message = '')
+	{
+		parent::setExpectedException($exception, $message);
+	}
+}

--- a/tests/Base/PHPUnit6.php
+++ b/tests/Base/PHPUnit6.php
@@ -1,0 +1,17 @@
+<?php
+
+class Base_PHPUnit6 extends PHPUnit\Framework\TestCase
+{
+	/**
+	 * @param string $exception
+	 * @param string $message
+	 * @return void
+	 */
+	public function expectException($exception, $message = '')
+	{
+		parent::expectException($exception);
+		if ($message !== '') {
+			parent::expectExceptionMessage($message);
+		}
+	}
+}

--- a/tests/Base/PHPUnit7.php
+++ b/tests/Base/PHPUnit7.php
@@ -1,0 +1,12 @@
+<?php
+
+class Base_PHPUnit7 extends PHPUnit\Framework\TestCase
+{
+	public function expectException(string $exception, string $message = ''): void
+	{
+		parent::expectException($exception);
+		if ($message !== '') {
+			parent::expectExceptionMessage($message);
+		}
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,24 +12,28 @@ if (!class_exists('PHPUnit\Framework\TestCase') && class_exists('PHPUnit_Framewo
 	class_alias('PHPUnit_Framework_TestCase', 'PHPUnit\Framework\TestCase');
 }
 
-class SwaggerGen_TestCase extends PHPUnit\Framework\TestCase
-{
+// Unify setting expected exception for different phpunit versions
 
-	/**
-	 * @param string $exception
-	 */
-	public function expectException($exception, $message = '')
-	{
-		// while setExpectedException accepts message to assert on, expectException does not
-		if (method_exists($this, 'setExpectedException')) {
-			$ret = $this->setExpectedException($exception, $message);
-		} else {
-			$ret = parent::expectException($exception);
-			if ($message !== '') {
-				parent::expectExceptionMessage($message);
-			}
-		}
-		return $ret;
-	}
+// starting with PHPUnit 7.0 `expectException()` needs parameter type-hint
+// it has to be in a separate file to prevent older php version from choking on static parameter type hints
+// before PHPUnit 6.0 there was `setExpectedException()`
+// inbetween there was `expectException()` without type hint
 
+if (class_exists('PHPUnit\Runner\Version')) {
+	$version = PHPUnit\Runner\Version::id();
+} else if (class_exists('PHPUnit_Runner_Version')) {
+	$version = PHPUnit_Runner_Version::id();
+} else {
+	throw new Exception('Cannot detect PHPUnit version');
+}
+
+if (version_compare($version, '7.0.0', '>=')) {
+	require dirname(__FILE__) . '/Base/PHPUnit7.php';
+	class_alias('Base_PHPUnit7', 'SwaggerGen_TestCase');
+} else if (version_compare($version, '6.0.0', '>=')) {
+	require dirname(__FILE__) . '/Base/PHPUnit6.php';
+	class_alias('Base_PHPUnit6', 'SwaggerGen_TestCase');
+} else {
+	require dirname(__FILE__) . '/Base/PHPUnit5.php';
+	class_alias('Base_PHPUnit5', 'SwaggerGen_TestCase');
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,15 +7,11 @@ spl_autoload_register(function($classname) {
 	}
 });
 
-// backward compatibility
-if (!class_exists('PHPUnit\Framework\TestCase') && class_exists('PHPUnit_Framework_TestCase')) {
-	class_alias('PHPUnit_Framework_TestCase', 'PHPUnit\Framework\TestCase');
-}
 
 // Unify setting expected exception for different phpunit versions
 
 // starting with PHPUnit 7.0 `expectException()` needs parameter type-hint
-// it has to be in a separate file to prevent older php version from choking on static parameter type hints
+// it has to be in a separate file to prevent older php version from choking on scalar parameter type hints
 // before PHPUnit 6.0 there was `setExpectedException()`
 // inbetween there was `expectException()` without type hint
 


### PR DESCRIPTION
This PR makes the test suite compatible with PHPUnit 7. Additionally, it splits PHPUnit version dependent code into separate classes for easier maintenance.