### PR TITLE
`example` command: support for json with multiple properties

### DIFF
--- a/SwaggerGen/Swagger/Type/AbstractType.php
+++ b/SwaggerGen/Swagger/Type/AbstractType.php
@@ -137,7 +137,7 @@ abstract class AbstractType extends \SwaggerGen\Swagger\AbstractObject
 				if ($data === '') {
 					throw new \SwaggerGen\Exception("Missing content for type example");
 				}
-				$json = preg_replace_callback('/([^{}:]+)/', function($match) {
+				$json = preg_replace_callback('/([^{}:,]+)/', function($match) {
 					json_decode($match[1]);
 					return json_last_error() === JSON_ERROR_NONE ? $match[1] : json_encode($match[1]);
 				}, trim($data));

--- a/tests/Swagger/Type/AbstractTypeTest.php
+++ b/tests/Swagger/Type/AbstractTypeTest.php
@@ -64,4 +64,23 @@ class AbstractTypeTest extends SwaggerGen_TestCase
 				), $object->toArray());
 	}
 
+	/**
+	 * @covers \SwaggerGen\Swagger\Type\AbstractType->handleCommand
+	 */
+	public function testCommand_Example_Json_Multiple_Properties()
+	{
+		$object = new SwaggerGen\Swagger\Type\StringType($this->parent, 'string');
+
+		$this->assertInstanceOf('\SwaggerGen\Swagger\Type\StringType', $object);
+
+		$object->handleCommand('example', '{foo:bar,baz:bat}');
+
+		$this->assertSame(array(
+			'type' => 'string',
+			'example' => array(
+				'foo' => 'bar',
+				'baz' => 'bat',
+			),
+				), $object->toArray());
+	}
 }


### PR DESCRIPTION
@vanderlee let me know if you'd prefer existing test case for json to be adjusted (instead of a separate test case)