### PR TITLE
`example` command: support for input containing special chars

### DIFF
--- a/SwaggerGen/Swagger/Type/AbstractType.php
+++ b/SwaggerGen/Swagger/Type/AbstractType.php
@@ -142,6 +142,17 @@ abstract class AbstractType extends \SwaggerGen\Swagger\AbstractObject
 					return json_last_error() === JSON_ERROR_NONE ? $match[1] : json_encode($match[1]);
 				}, trim($data));
 				$this->example = json_decode($json, true);
+
+				// In case input contains special chars, the above preg_replace would fail
+				//   Input could be a well-formed json already though
+				if ($this->example === null) {
+					$this->example = json_decode($data, true);
+				}
+				// If all fails, use input as-is
+				if ($this->example === null) {
+					$this->example = $data;
+				}
+
 				return $this;
 		}
 

--- a/tests/Swagger/Type/AbstractTypeTest.php
+++ b/tests/Swagger/Type/AbstractTypeTest.php
@@ -83,4 +83,38 @@ class AbstractTypeTest extends SwaggerGen_TestCase
 			),
 				), $object->toArray());
 	}
+
+	/**
+	 * @covers \SwaggerGen\Swagger\Type\AbstractType->handleCommand
+	 */
+	public function testCommand_Example_Json_String_With_Special_Chars()
+	{
+		$object = new SwaggerGen\Swagger\Type\StringType($this->parent, 'string');
+
+		$this->assertInstanceOf('\SwaggerGen\Swagger\Type\StringType', $object);
+
+		$object->handleCommand('example', '"2019-01-01 17:59:59"');
+
+		$this->assertSame(array(
+			'type' => 'string',
+			'example' => '2019-01-01 17:59:59',
+				), $object->toArray());
+	}
+
+	/**
+	 * @covers \SwaggerGen\Swagger\Type\AbstractType->handleCommand
+	 */
+	public function testCommand_Example_Invalid_Json_Not_Ignored()
+	{
+		$object = new SwaggerGen\Swagger\Type\StringType($this->parent, 'string');
+
+		$this->assertInstanceOf('\SwaggerGen\Swagger\Type\StringType', $object);
+
+		$object->handleCommand('example', '2019-01-01{}');
+
+		$this->assertSame(array(
+			'type' => 'string',
+			'example' => '2019-01-01{}',
+				), $object->toArray());
+	}
 }


### PR DESCRIPTION
also even in case input was invalid json - use it as is (instead of ignoring it)