### PR TITLE
Fix PHP parser such that it recognizes `property!` as a command

### DIFF
--- a/SwaggerGen/Parser/Php/Parser.php
+++ b/SwaggerGen/Parser/Php/Parser.php
@@ -156,7 +156,7 @@ class Parser extends Entity\AbstractEntity implements \SwaggerGen\Parser\IParser
 				$data = '';
 			}
 
-			if (preg_match('~^@' . preg_quote(self::COMMENT_TAG) . '\\\\([a-z][-a-z]*\\??)\\s*(.*)$~', $line, $match) === 1) {
+			if (preg_match('~^@' . preg_quote(self::COMMENT_TAG) . '\\\\([a-z][-a-z]*[?!]?)\\s*(.*)$~', $line, $match) === 1) {
 				$command = $match[1];
 				$data = $match[2];
 				$commandLineNumber = $lineNumber;

--- a/tests/Parser/Php/ParserTest.php
+++ b/tests/Parser/Php/ParserTest.php
@@ -221,6 +221,42 @@ class Parser_Php_ParserTest extends SwaggerGen_TestCase
 		$this->assertStatement($statements[0], 'title', 'Some words');
 	}
 
+    /**
+     * @covers \SwaggerGen\Parser\Php\Parser::parse
+     */
+    public function testParse_PropertyReadOnly()
+    {
+        $object = new \SwaggerGen\Parser\Php\Parser();
+        $this->assertInstanceOf('\SwaggerGen\Parser\Php\Parser', $object);
+
+        $statements = $object->parse(__DIR__ . '/ParserTest/testParse_PropertyReadOnly.php');
+
+        $this->assertCount(4, $statements);
+
+        $this->assertStatement($statements[0], 'title', 'Some words');
+        $this->assertStatement($statements[1], 'version', '2');
+        $this->assertStatement($statements[2], 'definition', 'Foo');
+        $this->assertStatement($statements[3], 'property!', 'string bar');
+    }
+
+    /**
+     * @covers \SwaggerGen\Parser\Php\Parser::parse
+     */
+    public function testParse_PropertyOptional()
+    {
+        $object = new \SwaggerGen\Parser\Php\Parser();
+        $this->assertInstanceOf('\SwaggerGen\Parser\Php\Parser', $object);
+
+        $statements = $object->parse(__DIR__ . '/ParserTest/testParse_PropertyOptional.php');
+
+        $this->assertCount(4, $statements);
+
+        $this->assertStatement($statements[0], 'title', 'Some words');
+        $this->assertStatement($statements[1], 'version', '2');
+        $this->assertStatement($statements[2], 'definition', 'Foo');
+        $this->assertStatement($statements[3], 'property?', 'string bar');
+    }
+
 	/**
 	 * @covers \SwaggerGen\Parser\Php\Parser::parse
 	 */

--- a/tests/Parser/Php/ParserTest/testParse_PropertyOptional.php
+++ b/tests/Parser/Php/ParserTest/testParse_PropertyOptional.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Test\Parser\Php\ParserTest;
+
+/*
+ * General comment
+ * @rest\title Some words
+ */
+
+/**
+ * Description of class
+ * @rest\version 2
+ * @rest\definition Foo
+ * @rest\property? string bar
+ */
+class testParse_PropertyOptional
+{
+
+}

--- a/tests/Parser/Php/ParserTest/testParse_PropertyReadOnly.php
+++ b/tests/Parser/Php/ParserTest/testParse_PropertyReadOnly.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Test\Parser\Php\ParserTest;
+
+/*
+ * General comment
+ * @rest\title Some words
+ */
+
+/**
+ * Description of class
+ * @rest\version 2
+ * @rest\definition Foo
+ * @rest\property! string bar
+ */
+class testParse_PropertyReadOnly
+{
+
+}


### PR DESCRIPTION
See #44.

I managed to add a unit test which fails without this change in place and decided to also add a test for the `?` suffix, since I was messing with that functionality.

Regards.