### PR TITLE
Replace implicit nullable types with explicitly nullable types

### DIFF
--- a/SwaggerGen/Parser/Php/Parser.php
+++ b/SwaggerGen/Parser/Php/Parser.php
@@ -349,7 +349,7 @@ class Parser extends Entity\AbstractEntity implements IParser
      * @throws Exception
      * @throws Exception
      */
-    private function expand(array $Statements, ParserClass $Self = null)
+    private function expand(array $Statements, ?ParserClass $Self = null)
     {
         $output = [];
 

--- a/SwaggerGen/Swagger/AbstractObject.php
+++ b/SwaggerGen/Swagger/AbstractObject.php
@@ -39,7 +39,7 @@ abstract class AbstractObject
      */
     private $extensions = array();
 
-    public function __construct(AbstractObject $parent = null)
+    public function __construct(?AbstractObject $parent = null)
     {
         $this->parent = $parent;
     }

--- a/SwaggerGen/Swagger/Operation.php
+++ b/SwaggerGen/Swagger/Operation.php
@@ -44,7 +44,7 @@ class Operation extends AbstractDocumentableObject
     /**
      * @param string $summary
      */
-    public function __construct(AbstractObject $parent, $summary = null, Tag $tag = null)
+    public function __construct(AbstractObject $parent, $summary = null, ?Tag $tag = null)
     {
         parent::__construct($parent);
         $this->summary = $summary;

--- a/SwaggerGen/Swagger/Path.php
+++ b/SwaggerGen/Swagger/Path.php
@@ -36,7 +36,7 @@ class Path extends AbstractObject
      */
     private $tag;
 
-    public function __construct(AbstractObject $parent, Tag $Tag = null)
+    public function __construct(AbstractObject $parent, ?Tag $Tag = null)
     {
         parent::__construct($parent);
         $this->tag = $Tag;


### PR DESCRIPTION
Implicitly nullable function parameters are deprecated in PHP 8.4. This pull request makes the parameters explicitly nullable to resolve the deprecation notice. Given the minimum supported version of PHP 7.1, there are no typed properties, so they should not be an issue.

See also: https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated