### PR TITLE
Align CI with the PHP 8 requirement

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,42 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.0', '8.1', '8.2', '8.3', '8.4']
+
+    name: PHP ${{ matrix.php }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: json, tokenizer, filter, mbstring
+          tools: composer:v2
+          coverage: none
+
+      - name: Validate Composer metadata
+        run: composer validate --strict
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run tests
+        run: composer test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
 
     name: PHP ${{ matrix.php }}
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: php
-dist: trusty
-php:
-  - 7.1
-  - 7.2
-  - hhvm
-matrix:
-    allow_failures:
-      - php: hhvm

--- a/composer.json
+++ b/composer.json
@@ -1,30 +1,33 @@
 {
-	"name": "vanderlee/swaggergen",
-	"description": "Generate Swagger/OpenAPI documentation from simple PHPdoc-like comments in PHP source code.",
-	"type": "library",
-	"keywords": ["swagger", "openapi", "doc", "documentation", "rest", "api", "documentor", "comments", "generate", "generator"],
-	"homepage": "https://github.com/vanderlee/PHPSwaggerGen",
-	"license": "MIT",
-	"support": {
-		"issues": "https://github.com/vanderlee/PHPSwaggerGen/issues",
-		"source": "https://github.com/vanderlee/PHPSwaggerGen/"
-	},
-	"require": {
-		"php": ">=8.0",
-		"ext-json": "*",
-		"ext-tokenizer": "*",
-		"ext-filter": "*",
-		"ext-mbstring": "*"
-	},
-	"suggest": {
-		"ext-yaml": "Allows producing Swagger docs in Yaml format"
-	},
-	"autoload": {
-		"psr-4": {
-			"SwaggerGen\\": "SwaggerGen/"
-		}
-	},
-	"require-dev": {
-		"phpunit/phpunit": "10"
-	}
+    "name": "vanderlee/swaggergen",
+    "description": "Generate Swagger/OpenAPI documentation from simple PHPdoc-like comments in PHP source code.",
+    "type": "library",
+    "keywords": ["swagger", "openapi", "doc", "documentation", "rest", "api", "documentor", "comments", "generate", "generator"],
+    "homepage": "https://github.com/vanderlee/PHPSwaggerGen",
+    "license": "MIT",
+    "support": {
+        "issues": "https://github.com/vanderlee/PHPSwaggerGen/issues",
+        "source": "https://github.com/vanderlee/PHPSwaggerGen/"
+    },
+    "require": {
+        "php": ">=8.0",
+        "ext-json": "*",
+        "ext-tokenizer": "*",
+        "ext-filter": "*",
+        "ext-mbstring": "*"
+    },
+    "suggest": {
+        "ext-yaml": "Allows producing Swagger docs in YAML format"
+    },
+    "autoload": {
+        "psr-4": {
+            "SwaggerGen\\": "SwaggerGen/"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.6 || ^10.5 || ^11.5"
+    },
+    "scripts": {
+        "test": "phpunit"
+    }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="tests/bootstrap.php"
          colors="true"
-         processIsolation="false"
-         verbose="true"
-         debug="true">
+         processIsolation="false">
   <testsuites>
     <testsuite name="SwaggerGen">
       <directory>tests</directory>

--- a/tests/SwaggerGenTest.php
+++ b/tests/SwaggerGenTest.php
@@ -92,7 +92,7 @@ class SwaggerGenTest extends \PHPUnit\Framework\TestCase
 			response 202
 		'), array(), SwaggerGen::FORMAT_JSON_PRETTY);
 
-        $this->assertStringEqualsStringIgnoringLineEndings(<<<JSON
+        $expected = <<<JSON
 {
     "swagger": "2.0",
     "info": {
@@ -111,7 +111,13 @@ class SwaggerGenTest extends \PHPUnit\Framework\TestCase
         }
     }
 }
-JSON, $output);
+JSON;
+
+        $normalizeLineEndings = static function ($value) {
+            return str_replace(array("\r\n", "\r"), "\n", $value);
+        };
+
+        $this->assertSame($normalizeLineEndings($expected), $normalizeLineEndings($output));
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,9 @@
 <?php
 
+if (!class_exists('SwaggerGen_TestCase', false)) {
+    class_alias('PHPUnit\\Framework\\TestCase', 'SwaggerGen_TestCase');
+}
+
 spl_autoload_register(function ($classname) {
     $file = dirname(__DIR__) . DIRECTORY_SEPARATOR . str_replace('\\', DIRECTORY_SEPARATOR, $classname) . '.php';
     if (is_file($file)) {

--- a/tests/output/OutputTest.php
+++ b/tests/output/OutputTest.php
@@ -15,7 +15,7 @@ class OutputTest extends TestCase
     {
         $SwaggerGen = new SwaggerGen('example.com', '/base');
         $actual = $SwaggerGen->getSwagger($files, array(), SwaggerGen::FORMAT_JSON);
-        $this->assertJsonStringEqualsJsonString($expected, $this->normalizeJson($actual), $name);
+        $this->assertJsonStringEqualsJsonString($expected, self::normalizeJson($actual), $name);
     }
 
     /**
@@ -26,7 +26,7 @@ class OutputTest extends TestCase
      * @param string $json
      * @return string
      */
-    private function normalizeJson($json)
+    private static function normalizeJson($json)
     {
         return json_encode(
             json_decode($json),
@@ -34,13 +34,13 @@ class OutputTest extends TestCase
         );
     }
 
-    public function provideAllCases()
+    public static function provideAllCases()
     {
         $cases = array();
 
         foreach (glob(__DIR__ . '/*', GLOB_ONLYDIR) as $dir) {
             $path = realpath($dir);
-            $json = $this->normalizeJson(file_get_contents($path . '/expected.json'));
+            $json = self::normalizeJson(file_get_contents($path . '/expected.json'));
 
             $files = array();
             if (file_exists($path . '/source.php')) {


### PR DESCRIPTION
## What changed
- Replace the obsolete PHP 7-era Travis build with GitHub Actions.
- Test the declared PHP 8.0+ support across PHP 8.0 through 8.5.
- Allow Composer to resolve an appropriate maintained PHPUnit major for each runtime.
- Add a `composer test` script and strict Composer validation.
- Restore the shared PHPUnit test base alias, modernize the output data provider, and remove obsolete PHPUnit XML attributes.
- Use assertions compatible with PHPUnit 9 through 11.

## Why
`composer.json` requires PHP 8.0, but the existing CI only targeted PHP 7.1, PHP 7.2, and HHVM. The old test bootstrap and fixtures also depended on PHPUnit APIs that changed across the supported runtime range.

## Validation
The GitHub Actions matrix passes on PHP 8.0, 8.1, 8.2, 8.3, 8.4, and 8.5.