### PR TITLE
Expand preprocessor variables in generated documentation

### DIFF
--- a/SwaggerGen/Parser/AbstractPreprocessor.php
+++ b/SwaggerGen/Parser/AbstractPreprocessor.php
@@ -50,7 +50,7 @@ abstract class AbstractPreprocessor
     {
         $this->stack = [];
 
-        return $this->parseContent($content);
+        return $this->expandDefines($this->parseContent($content));
     }
 
     abstract protected function parseContent($content);
@@ -111,6 +111,21 @@ abstract class AbstractPreprocessor
         }
 
         return true;
+    }
+
+    private function expandDefines($content)
+    {
+        return preg_replace_callback(
+            '/\{([A-Za-z_][A-Za-z0-9_.-]*)\}/',
+            function ($matches) {
+                $name = $matches[1];
+
+                return array_key_exists($name, $this->defines)
+                    ? (string) $this->defines[$name]
+                    : $matches[0];
+            },
+            $content
+        );
     }
 
     /**

--- a/tests/Parser/VariableExpansionTest.php
+++ b/tests/Parser/VariableExpansionTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use SwaggerGen\Parser\Php\Preprocessor as PhpPreprocessor;
+use SwaggerGen\Parser\Text\Preprocessor as TextPreprocessor;
+
+class VariableExpansionTest extends TestCase
+{
+    public function testPhpPreprocessorExpandsDefinedValues(): void
+    {
+        $preprocessor = new PhpPreprocessor();
+        $preprocessor->define('api_version', '2.4.1');
+
+        $source = "<?php\n/** @rest\\version {api_version} */\n";
+
+        $this->assertSame(
+            "<?php\n/** @rest\\version 2.4.1 */\n",
+            $preprocessor->preprocess($source)
+        );
+    }
+
+    public function testTextPreprocessorExpandsDefinedValues(): void
+    {
+        $preprocessor = new TextPreprocessor();
+        $preprocessor->define('api_version', '2.4.1');
+
+        $this->assertSame(
+            'Version 2.4.1',
+            $preprocessor->preprocess('Version {api_version}')
+        );
+    }
+
+    public function testUndefinedValuesRemainVisible(): void
+    {
+        $preprocessor = new TextPreprocessor();
+
+        $this->assertSame(
+            'Version {api_version}',
+            $preprocessor->preprocess('Version {api_version}')
+        );
+    }
+}


### PR DESCRIPTION
## What changed
- Expand `{name}` placeholders after conditional preprocessing using values supplied through `define()` or `addDefines()`.
- Preserve unknown placeholders unchanged so documentation can be processed in multiple stages.
- Add coverage for both PHP-comment and plain-text preprocessors.

## Why
This implements the long-standing request in issue #36, allowing definitions such as `define('api_version', '2.4.1')` to be referenced as `@rest\version {api_version}`.

Expansion happens after inactive content has been filtered, so values are only inserted into content that survives preprocessing.

## Validation
Not run locally because this environment cannot clone GitHub or install dependencies. The PR is a draft pending the repository test suite.

Closes #36.