### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,44 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php:
+          - '8.1'
+          - '8.4'
+
+    name: PHP ${{ matrix.php }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: json, tokenizer, filter, mbstring
+          tools: composer:v2
+          coverage: none
+
+      - name: Validate Composer metadata
+        run: composer validate --strict
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Run tests
+        run: vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: php
-dist: trusty
-php:
-  - 7.1
-  - 7.2
-  - hhvm
-matrix:
-    allow_failures:
-      - php: hhvm


### PR DESCRIPTION
## What changed
- Replace Travis CI with a GitHub Actions PHP matrix.
- Test PHP 8.1 and 8.4, which satisfy the current PHPUnit 10 development dependency.
- Validate Composer metadata, install dependencies, and run the existing PHPUnit suite.
- Restrict workflow permissions to read-only repository contents.

## Why
The committed Travis configuration targets PHP 7.1/7.2 and HHVM, while the current package now requires PHP 8 and PHPUnit 10. The new workflow aligns CI with the repository's actual dependency constraints.

## Validation
The draft workflow will run both PHP jobs on this pull request.