### PR TITLE
Add PHP 8.6 to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,11 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.php == '8.6' }}
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5', '8.6']
 
     name: PHP ${{ matrix.php }}
 


### PR DESCRIPTION
## Summary

- add PHP 8.6 to the test matrix
- keep the PHP 8.6 nightly job non-blocking while the runtime is still in development

## Impact

This provides early compatibility feedback without allowing nightly runtime regressions to block the stable PHP test suite.

## Validation

- PHP 8.6 nightly: passing
- existing stable matrix entries: passing